### PR TITLE
Close footnote popups with escape key

### DIFF
--- a/html/js/footnotes.js
+++ b/html/js/footnotes.js
@@ -18,14 +18,23 @@ $(document).ready(function () {
       body.unbind('click', Footnotes.bodyclick);
       footnotelinks.unbind('click', Footnotes.footnoteclick);
       footnotelinks.unbind('blur', Footnotes.footnoteout);
+      $(document).unbind('keydown', Footnotes.keydown);
 
       body.bind('click', Footnotes.bodyclick);
       // Bind new behaviour where click will pop up the footnote:
       footnotelinks.bind('click', Footnotes.footnoteclick);
       // ...and click outside of popup will make it disappear:
       footnotelinks.bind('blur', Footnotes.footnoteout);
+      // ...escape key should also do the job:
+      $(document).bind('keydown', Footnotes.keydown);
     },
     bodyclick: function () { return; },
+    keydown: function (event) {
+      // Capture escape key.
+      if (event.which == 27) {
+        Footnotes.footnoteout();
+      }
+    },
     footnoteclick: function () {
       clearTimeout(Footnotes.footnotetimeout);
       $(popup).stop();


### PR DESCRIPTION
While browsing the book using keyboard (in my case with Vimium extension enabled) everything works fine except that you need a mouse to close footnote popups. This issue is quite annoying sometimes.

Closing popups with escape key can definitely save the day.
