### PR TITLE
Modify `inkscape` command to be compatible with Inkscape 1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ $(META): $(NEXUS) create_metafiles.rb
 	./create_metafiles.rb
 
 $(THUMB): $(COVER)
-	@inkscape -b "#fbfbfb" -C -e $(THUMB) -f $(DIR)fig/coverpage.std.svg > /dev/null
+	@inkscape $(DIR)fig/coverpage.std.svg -b "#fbfbfb" -C --export-filename=$(THUMB) > /dev/null
 
 $(GOAL): $(META) $(THUMB) $(FIG) $(CSS) $(FONT) mimetype META-INF/* LICENSE
 	@if [ -f $(GOAL) ]; then rm $(GOAL); fi; \


### PR DESCRIPTION
Inkscape 1 has [dropped the -e and -f flags](https://wiki.inkscape.org/wiki/index.php/Using_the_Command_Line#Changes_from_0.92).

This PR updates the Makefile accordingly.