### PR TITLE
Put SVG illustrations inside <img> instead of <object>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ HIGHL = $(DIR)js/highlight/
 PRETTY = $(HIGHL)prettify.js $(HIGHL)lang-lisp.js batch-prettify.js
 COVER = index.in.xhtml $(DIR)fig/coverpage.std.svg $(DIR)fig/bookwheel.jpg
 THUMB = $(DIR)fig/cover.png     # thumbnail cover image
-SHELL = /bin/bash
+SHELL = /usr/bin/env bash
 
 JQ = <script src=\"js/jquery.min.js\" type=\"text/javascript\"></script>
 FT = <script src=\"js/footnotes.js\" type=\"text/javascript\"></script>

--- a/html/1_002e1.xhtml
+++ b/html/1_002e1.xhtml
@@ -299,7 +299,7 @@ general kind of process known as <a id="index-tree-accumulation"></a>
 </p>
 <figure class="float">
 <a id="Figure-1_002e1"></a>
-<object style="width: 20.38ex; height: 20.46ex;" data="fig/chap1/Fig1.1g.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap1/Fig1.1g.std.svg" style="width: 20.38ex; height: 20.46ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 1.1:</strong> Tree representation, showing the value of each subcombination.</p>
@@ -1326,7 +1326,7 @@ problem into subproblems.
 </p>
 <figure class="float">
 <a id="Figure-1_002e2"></a>
-<object style="width: 34.97ex; height: 15.63ex;" data="fig/chap1/Fig1.2.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap1/Fig1.2.std.svg" style="width: 34.97ex; height: 15.63ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 1.2:</strong> Procedural decomposition of the <code>sqrt</code> program.</p>

--- a/html/1_002e2.xhtml
+++ b/html/1_002e2.xhtml
@@ -216,7 +216,7 @@ procedure in action computing 6!, as shown in <a href="#Figure-1_002e3">Figure 1
 </p>
 <figure class="float">
 <a id="Figure-1_002e3"></a>
-<object style="width: 52.58ex; height: 31.43ex;" data="fig/chap1/Fig1.3d.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap1/Fig1.3d.std.svg" style="width: 52.58ex; height: 31.43ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 1.3:</strong> A linear recursive process for computing 6!.</p>
@@ -278,7 +278,7 @@ computing 6!, as shown in <a href="#Figure-1_002e4">Figure 1.4</a>.
 </p>
 <figure class="float">
 <a id="Figure-1_002e4"></a>
-<object style="width: 23.40ex; height: 23.31ex;" data="fig/chap1/Fig1.4d.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap1/Fig1.4d.std.svg" style="width: 23.40ex; height: 23.31ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 1.4:</strong> A linear iterative process for computing 6!.</p>
@@ -554,7 +554,7 @@ that the <code>fib</code> procedure calls itself twice each time it is invoked.
 </p>
 <figure class="float">
 <a id="Figure-1_002e5"></a>
-<object style="width: 58.07ex; height: 36.18ex;" data="fig/chap1/Fig1.5d.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap1/Fig1.5d.std.svg" style="width: 58.07ex; height: 36.18ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 1.5:</strong> The tree-recursive process generated in computing <code>(fib 5)</code>.</p>

--- a/html/2_002e1.xhtml
+++ b/html/2_002e1.xhtml
@@ -617,7 +617,7 @@ barriers and connect the different levels.
 </p>
 <figure class="float">
 <a id="Figure-2_002e1"></a>
-<object style="width: 48.87ex; height: 38.08ex;" data="fig/chap2/Fig2.1d.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.1d.std.svg" style="width: 48.87ex; height: 38.08ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.1:</strong> Data-abstraction barriers in the rational-number package.</p>

--- a/html/2_002e2.xhtml
+++ b/html/2_002e2.xhtml
@@ -48,7 +48,7 @@ containing the <code>cdr</code>.
 </p>
 <figure class="float">
 <a id="Figure-2_002e2"></a>
-<object style="width: 21.76ex; height: 11.83ex;" data="fig/chap2/Fig2.2e.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.2e.std.svg" style="width: 21.76ex; height: 11.83ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.2:</strong> Box-and-pointer representation of <code>(cons 1 2)</code>.</p>
@@ -64,7 +64,7 @@ numbers 1, 2, 3, and 4.
 </p>
 <figure class="float">
 <a id="Figure-2_002e3"></a>
-<object style="width: 55.60ex; height: 28.41ex;" data="fig/chap2/Fig2.3e.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.3e.std.svg" style="width: 55.60ex; height: 28.41ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.3:</strong> Two ways to combine 1, 2, 3, and 4 using pairs.</p>
@@ -117,7 +117,7 @@ nested <code>cons</code> operations:
 
 <figure class="float">
 <a id="Figure-2_002e4"></a>
-<object style="width: 48.95ex; height: 11.83ex;" data="fig/chap2/Fig2.4e.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.4e.std.svg" style="width: 48.95ex; height: 11.83ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.4:</strong> The sequence 1, 2, 3, 4 represented as a chain of pairs.</p>
@@ -610,7 +610,7 @@ this structure in terms of pairs.
 </p>
 <figure class="float">
 <a id="Figure-2_002e5"></a>
-<object style="width: 51.89ex; height: 25.73ex;" data="fig/chap2/Fig2.5e.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.5e.std.svg" style="width: 51.89ex; height: 25.73ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.5:</strong> Structure formed by <code>(cons (list 1 2) (list 3 4))</code>.</p>
@@ -625,7 +625,7 @@ shows the structure in <a href="#Figure-2_002e5">Figure 2.5</a> viewed as a tree
 </p>
 <figure class="float">
 <a id="Figure-2_002e6"></a>
-<object style="width: 15.02ex; height: 17.01ex;" data="fig/chap2/Fig2.6b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.6b.std.svg" style="width: 15.02ex; height: 17.01ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.6:</strong> The list structure in <a href="#Figure-2_002e5">Figure 2.5</a> viewed as a tree.</p>
@@ -1025,7 +1025,7 @@ elements using <code>+</code>, starting from an initial 0.  The plan for
 </p>
 <figure class="float">
 <a id="Figure-2_002e7"></a>
-<object style="width: 57.93ex; height: 16.23ex;" data="fig/chap2/Fig2.7e.std.svg" type="image/svg+xml">SVG</object> 
+<img src="fig/chap2/Fig2.7e.std.svg" style="width: 57.93ex; height: 16.23ex;" /> 
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.7:</strong> The signal-flow plans for the procedures <code>sum-odd-squares</code> (top) and <code>even-fibs</code> (bottom) reveal the commonality between the two programs.</p>
@@ -2252,7 +2252,7 @@ produce not only one solution, but all solutions to the puzzle.
 </p>
 <figure class="float">
 <a id="Figure-2_002e8"></a>
-<object style="width: 33.41ex; height: 33.41ex;" data="fig/chap2/Fig2.8c.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.8c.std.svg" style="width: 33.41ex; height: 33.41ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.8:</strong> A solution to the eight-queens puzzle.</p>
@@ -2381,7 +2381,7 @@ build arbitrarily complicated patterns.
 </p>
 <figure class="float">
 <a id="Figure-2_002e9"></a>
-<object style="width: 55.86ex; height: 31.34ex;" data="fig/chap2/Fig2.9.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.9.std.svg" style="width: 55.86ex; height: 31.34ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.9:</strong> Designs generated with the picture language.</p>
@@ -2411,7 +2411,7 @@ frames as the <code>wave</code> images in figure 2.10.
 </p>
 <figure class="float">
 <a id="Figure-2_002e10"></a>
-<object style="width: 28.23ex; height: 30.22ex;" data="fig/chap2/Fig2.10.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.10.std.svg" style="width: 28.23ex; height: 30.22ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.10:</strong> Images produced by the <code>wave</code> painter, with respect to four different frames.  The frames, shown with dotted lines, are not part of the images.</p>
@@ -2420,7 +2420,7 @@ frames as the <code>wave</code> images in figure 2.10.
 
 <figure class="float">
 <a id="Figure-2_002e11"></a>
-<object style="width: 28.23ex; height: 31.26ex;" data="fig/chap2/Fig2.11.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.11.std.svg" style="width: 28.23ex; height: 31.26ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.11:</strong> Images of William Barton Rogers, founder and first president of <abbr>MIT</abbr>, painted with respect to the same four frames as in <a href="#Figure-2_002e10">Figure 2.10</a> (original image from Wikimedia Commons).</p>
@@ -2447,7 +2447,7 @@ original painter’s image left-to-right reversed.
 
 <figure class="float">
 <a id="Figure-2_002e12"></a>
-<object style="width: 47.06ex; height: 26.07ex;" data="fig/chap2/Fig2.12.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.12.std.svg" style="width: 47.06ex; height: 26.07ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.12:</strong> Creating a complex figure, starting from the <code>wave</code> painter of <a href="#Figure-2_002e10">Figure 2.10</a>.</p>
@@ -2497,7 +2497,7 @@ and <a href="#Figure-2_002e14">Figure 2.14</a>:
 
 <figure class="float">
 <a id="Figure-2_002e13"></a>
-<object style="width: 52.15ex; height: 68.90ex;" data="fig/chap2/Fig2.13a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.13a.std.svg" style="width: 52.15ex; height: 68.90ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.13:</strong> Recursive plans for <code>right-split</code> and <code>corner-split</code>.</p>
@@ -2525,7 +2525,7 @@ right (see <a href="#Exercise-2_002e44">Exercise 2.44</a>, <a href="#Figure-2_00
 
 <figure class="float">
 <a id="Figure-2_002e14"></a>
-<object style="width: 52.93ex; height: 62.25ex;" data="fig/chap2/Fig2.14b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.14b.std.svg" style="width: 52.93ex; height: 62.25ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.14:</strong> The recursive operations <code>right-split</code> and <code>corner-split</code> applied to the painters <code>wave</code> and <code>rogers</code>.  Combining four <code>corner-split</code> figures produces symmetric <code>square-limit</code> designs as shown in <a href="#Figure-2_002e9">Figure 2.9</a>.</p>
@@ -2634,7 +2634,7 @@ corresponding selectors <code>origin-frame</code>, <code>edge1-frame</code>, and
 </p>
 <figure class="float">
 <a id="Figure-2_002e15"></a>
-<object style="width: 34.02ex; height: 32.03ex;" data="fig/chap2/Fig2.15a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.15a.std.svg" style="width: 34.02ex; height: 32.03ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.15:</strong> A frame is described by three vectors — an origin and two edges.</p>

--- a/html/2_002e3.xhtml
+++ b/html/2_002e3.xhtml
@@ -1114,7 +1114,7 @@ elements in the right subtree be larger.
 </p>
 <figure class="float">
 <a id="Figure-2_002e16"></a>
-<object style="width: 45.93ex; height: 21.50ex;" data="fig/chap2/Fig2.16c.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.16c.std.svg" style="width: 45.93ex; height: 21.50ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.16:</strong> Various binary trees that represent the set <math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -1273,7 +1273,7 @@ steps.<a class="footnote_link" id="DOCF106" href="#FOOT106"><sup>106</sup></a>
 </p>
 <figure class="float">
 <a id="Figure-2_002e17"></a>
-<object style="width: 26.68ex; height: 26.51ex;" data="fig/chap2/Fig2.17a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.17a.std.svg" style="width: 26.68ex; height: 26.51ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.17:</strong> Unbalanced tree produced by adjoining 1 through 7 in sequence.</p>
@@ -1564,7 +1564,7 @@ other letters each with relative frequency 1.
 </p>
 <figure class="float">
 <a id="Figure-2_002e18"></a>
-<object style="width: 53.01ex; height: 35.23ex;" data="fig/chap2/Fig2.18a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.18a.std.svg" style="width: 53.01ex; height: 35.23ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.18:</strong> A Huffman encoding tree.</p>

--- a/html/2_002e4.xhtml
+++ b/html/2_002e4.xhtml
@@ -109,7 +109,7 @@ and install alternative representations.
 </p>
 <figure class="float">
 <a id="Figure-2_002e19"></a>
-<object style="width: 40.41ex; height: 33.41ex;" data="fig/chap2/Fig2.19a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.19a.std.svg" style="width: 40.41ex; height: 33.41ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.19:</strong> Data-abstraction barriers in the complex-number system.</p>
@@ -262,7 +262,7 @@ coordinates:
 </p>
 <figure class="float">
 <a id="Figure-2_002e20"></a>
-<object style="width: 51.98ex; height: 30.74ex;" data="fig/chap2/Fig2.20.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.20.std.svg" style="width: 51.98ex; height: 30.74ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.20:</strong> Complex numbers as points in the plane.</p>
@@ -761,7 +761,7 @@ interface.
 </p>
 <figure class="float">
 <a id="Figure-2_002e21"></a>
-<object style="width: 65.01ex; height: 33.59ex;" data="fig/chap2/Fig2.21a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.21a.std.svg" style="width: 65.01ex; height: 33.59ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.21:</strong> Structure of the generic complex-arithmetic system.</p>
@@ -835,7 +835,7 @@ same information could have been organized in a table, as shown in <a href="#Fig
 </p>
 <figure class="float">
 <a id="Figure-2_002e22"></a>
-<object style="width: 63.29ex; height: 20.98ex;" data="fig/chap2/Fig2.22.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.22.std.svg" style="width: 63.29ex; height: 20.98ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.22:</strong> Table of operations for the complex-number system.</p>

--- a/html/2_002e5.xhtml
+++ b/html/2_002e5.xhtml
@@ -63,7 +63,7 @@ system.
 </p>
 <figure class="float">
 <a id="Figure-2_002e23"></a>
-<object style="width: 59.40ex; height: 54.22ex;" data="fig/chap2/Fig2.23b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.23b.std.svg" style="width: 59.40ex; height: 54.22ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.23:</strong> Generic arithmetic system.</p>
@@ -260,7 +260,7 @@ package is stripped off (by applying <code>contents</code>) and the next level o
 </p>
 <figure class="float">
 <a id="Figure-2_002e24"></a>
-<object style="width: 41.53ex; height: 12.00ex;" data="fig/chap2/Fig2.24d.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.24d.std.svg" style="width: 41.53ex; height: 12.00ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.24:</strong> Representation of <math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -523,7 +523,7 @@ subtype.  Such a structure, called a <a id="index-tower"></a>
 </p>
 <figure class="float">
 <a id="Figure-2_002e25"></a>
-<object style="width: 8.46ex; height: 22.71ex;" data="fig/chap2/Fig2.25.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.25.std.svg" style="width: 8.46ex; height: 22.71ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.25:</strong> A tower of types.</p>
@@ -627,7 +627,7 @@ difficult, and is an area of much current research.<a class="footnote_link" id="
 </p>
 <figure class="float">
 <a id="Figure-2_002e26"></a>
-<object style="width: 68.12ex; height: 44.21ex;" data="fig/chap2/Fig2.26f.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap2/Fig2.26f.std.svg" style="width: 68.12ex; height: 44.21ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 2.26:</strong> Relations among types of geometric figures.</p>

--- a/html/3_002e2.xhtml
+++ b/html/3_002e2.xhtml
@@ -85,7 +85,7 @@ frame II is said to <a id="index-shadow"></a>
 </p>
 <figure class="float">
 <a id="Figure-3_002e1"></a>
-<object style="width: 26.51ex; height: 23.31ex;" data="fig/chap3/Fig3.1b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.1b.std.svg" style="width: 26.51ex; height: 23.31ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.1:</strong> A simple environment structure.</p>
@@ -165,7 +165,7 @@ with the symbol <code>square</code>, has been added to the global frame.  In gen
 </p>
 <figure class="float">
 <a id="Figure-3_002e2"></a>
-<object style="width: 33.85ex; height: 27.37ex;" data="fig/chap3/Fig3.2b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.2b.std.svg" style="width: 33.85ex; height: 27.37ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.2:</strong> Environment structure produced by evaluating <code>(define (square x) (* x x))</code> in the global environment.</p>
@@ -193,7 +193,7 @@ Since the value of <code>x</code> in E1 is 5, the result is <code>(* 5 5)</code>
 </p>
 <figure class="float">
 <a id="Figure-3_002e3"></a>
-<object style="width: 52.49ex; height: 27.37ex;" data="fig/chap3/Fig3.3b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.3b.std.svg" style="width: 52.49ex; height: 27.37ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.3:</strong> Environment created by evaluating <code>(square 5)</code> in the global environment.</p>
@@ -259,7 +259,7 @@ global environment.
 </p>
 <figure class="float">
 <a id="Figure-3_002e4"></a>
-<object style="width: 54.14ex; height: 35.83ex;" data="fig/chap3/Fig3.4b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.4b.std.svg" style="width: 54.14ex; height: 35.83ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.4:</strong> Procedure objects in the global frame.</p>
@@ -276,7 +276,7 @@ bound to the argument 5.  In E1, we evaluate the body of <code>f</code>:
 
 <figure class="float">
 <a id="Figure-3_002e5"></a>
-<object style="width: 57.93ex; height: 31.17ex;" data="fig/chap3/Fig3.5b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.5b.std.svg" style="width: 57.93ex; height: 31.17ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.5:</strong> Environments created by evaluating <code>(f 5)</code> using<!-- /@w --> the procedures in <a href="#Figure-3_002e4">Figure 3.4</a>.</p>
@@ -387,7 +387,7 @@ is itself a λ-expression.
 </p>
 <figure class="float">
 <a id="Figure-3_002e6"></a>
-<object style="width: 51.72ex; height: 36.87ex;" data="fig/chap3/Fig3.6c.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.6c.std.svg" style="width: 51.72ex; height: 36.87ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.6:</strong> Result of defining <code>make-withdraw</code> in the global environment.</p>
@@ -413,7 +413,7 @@ since the <code>define</code> itself is being evaluated in the global environmen
 </p>
 <figure class="float">
 <a id="Figure-3_002e7"></a>
-<object style="width: 59.06ex; height: 40.41ex;" data="fig/chap3/Fig3.7b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.7b.std.svg" style="width: 59.06ex; height: 40.41ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.7:</strong> Result of evaluating <code>(define W1 (make-withdraw 100))</code>.</p>
@@ -448,7 +448,7 @@ E1.
 </p>
 <figure class="float">
 <a id="Figure-3_002e8"></a>
-<object style="width: 58.97ex; height: 43.69ex;" data="fig/chap3/Fig3.8c.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.8c.std.svg" style="width: 58.97ex; height: 43.69ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.8:</strong> Environments created by applying the procedure object <code>W1</code>.</p>
@@ -469,7 +469,7 @@ situation after the call to <code>W1</code>.
 </p>
 <figure class="float">
 <a id="Figure-3_002e9"></a>
-<object style="width: 59.49ex; height: 32.72ex;" data="fig/chap3/Fig3.9b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.9b.std.svg" style="width: 59.49ex; height: 32.72ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.9:</strong> Environments after the call to <code>W1</code>.</p>
@@ -496,7 +496,7 @@ one object do not affect the other object.
 </p>
 <figure class="float">
 <a id="Figure-3_002e10"></a>
-<object style="width: 59.66ex; height: 38.68ex;" data="fig/chap3/Fig3.10b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.10b.std.svg" style="width: 59.66ex; height: 38.68ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.10:</strong> Using <code>(define W2 (make-withdraw 100))</code> to create a second object.</p>
@@ -570,7 +570,7 @@ been called for the first time with <code>guess</code> equal to 1.
 </p>
 <figure class="float">
 <a id="Figure-3_002e11"></a>
-<object style="width: 60.01ex; height: 56.90ex;" data="fig/chap3/Fig3.11b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.11b.std.svg" style="width: 60.01ex; height: 56.90ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.11:</strong> <code>Sqrt</code> procedure with internal definitions.</p>

--- a/html/3_002e3.xhtml
+++ b/html/3_002e3.xhtml
@@ -93,7 +93,7 @@ replaced, are now detached from the original structure.<a class="footnote_link" 
 </p>
 <figure class="float">
 <a id="Figure-3_002e12"></a>
-<object style="width: 48.18ex; height: 37.82ex;" data="fig/chap3/Fig3.12b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.12b.std.svg" style="width: 48.18ex; height: 37.82ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.12:</strong> Lists <code>x</code>: <code>((a b) c d)</code> and <code>y</code>: <code>(e f)</code>.</p>
@@ -102,7 +102,7 @@ replaced, are now detached from the original structure.<a class="footnote_link" 
 
 <figure class="float">
 <a id="Figure-3_002e13"></a>
-<object style="width: 48.18ex; height: 37.82ex;" data="fig/chap3/Fig3.13b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.13b.std.svg" style="width: 48.18ex; height: 37.82ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.13:</strong> Effect of <code>(set-car! x y)</code> on the lists in <a href="#Figure-3_002e12">Figure 3.12</a>.</p>
@@ -117,7 +117,7 @@ bound to a new pair created by the <code>cons</code> operation; the list to whic
 </p>
 <figure class="float">
 <a id="Figure-3_002e14"></a>
-<object style="width: 48.18ex; height: 38.68ex;" data="fig/chap3/Fig3.14b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.14b.std.svg" style="width: 48.18ex; height: 38.68ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.14:</strong> Effect of <code>(define z (cons y (cdr x)))</code> on the lists in <a href="#Figure-3_002e12">Figure 3.12</a>.</p>
@@ -134,7 +134,7 @@ is now detached from the structure.
 </p>
 <figure class="float">
 <a id="Figure-3_002e15"></a>
-<object style="width: 48.18ex; height: 37.82ex;" data="fig/chap3/Fig3.15b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.15b.std.svg" style="width: 48.18ex; height: 37.82ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.15:</strong> Effect of <code>(set-cdr! x y)</code> on the lists in <a href="#Figure-3_002e12">Figure 3.12</a>.</p>
@@ -277,7 +277,7 @@ in which many individual pairs are shared by many different structures.
 </p>
 <figure class="float">
 <a id="Figure-3_002e16"></a>
-<object style="width: 31.08ex; height: 19.69ex;" data="fig/chap3/Fig3.16b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.16b.std.svg" style="width: 31.08ex; height: 19.69ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.16:</strong> The list <code>z1</code> formed by <code>(cons x x)</code>.</p>
@@ -293,7 +293,7 @@ by
 
 <figure class="float">
 <a id="Figure-3_002e17"></a>
-<object style="width: 47.57ex; height: 17.96ex;" data="fig/chap3/Fig3.17b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.17b.std.svg" style="width: 47.57ex; height: 17.96ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.17:</strong> The list <code>z2</code> formed by <code>(cons (list 'a 'b) (list 'a 'b))</code>.</p>
@@ -493,7 +493,7 @@ called a <a id="index-FIFO"></a>
 </p>
 <figure class="float">
 <a id="Figure-3_002e18"></a>
-<object style="width: 48.01ex; height: 23.05ex;" data="fig/chap3/Fig3.18.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.18.std.svg" style="width: 48.01ex; height: 23.05ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.18:</strong> Queue operations.</p>
@@ -583,7 +583,7 @@ representation.
 </p>
 <figure class="float">
 <a id="Figure-3_002e19"></a>
-<object style="width: 46.54ex; height: 22.45ex;" data="fig/chap3/Fig3.19b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.19b.std.svg" style="width: 46.54ex; height: 22.45ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.19:</strong> Implementation of a queue as a list with front and rear pointers.</p>
@@ -633,7 +633,7 @@ also set the rear pointer to the new pair.
 </p>
 <figure class="float">
 <a id="Figure-3_002e20"></a>
-<object style="width: 55.09ex; height: 22.45ex;" data="fig/chap3/Fig3.20c.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.20c.std.svg" style="width: 55.09ex; height: 22.45ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.20:</strong> Result of using <code>(insert-queue! q 'd)</code> on the queue of <a href="#Figure-3_002e19">Figure 3.19</a>.</p>
@@ -669,7 +669,7 @@ found by following the <code>cdr</code> pointer of the first item (see
 
 <figure class="float">
 <a id="Figure-3_002e21"></a>
-<object style="width: 55.09ex; height: 22.45ex;" data="fig/chap3/Fig3.21c.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.21c.std.svg" style="width: 55.09ex; height: 22.45ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.21:</strong> Result of using <code>(delete-queue!  q)</code> on the queue of <a href="#Figure-3_002e20">Figure 3.20</a>.</p>
@@ -779,7 +779,7 @@ c</span><span class="pun">:</span><span class="pln">  </span><span class="lit">3
 
 <figure class="float">
 <a id="Figure-3_002e22"></a>
-<object style="width: 53.27ex; height: 27.11ex;" data="fig/chap3/Fig3.22c.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.22c.std.svg" style="width: 53.27ex; height: 27.11ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.22:</strong> A table represented as a headed list.</p>
@@ -851,7 +851,7 @@ since the key that identifies the subtable serves this purpose.)
 </p>
 <figure class="float">
 <a id="Figure-3_002e23"></a>
-<object style="width: 57.42ex; height: 55.95ex;" data="fig/chap3/Fig3.23b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.23b.std.svg" style="width: 57.42ex; height: 55.95ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.23:</strong> A two-dimensional table.</p>
@@ -1100,7 +1100,7 @@ otherwise the output will become 0.
 </p>
 <figure class="float">
 <a id="Figure-3_002e24"></a>
-<object style="width: 49.30ex; height: 11.14ex;" data="fig/chap3/Fig3.24a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.24a.std.svg" style="width: 49.30ex; height: 11.14ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.24:</strong> Primitive functions in the digital logic simulator.</p>
@@ -1120,7 +1120,7 @@ of the difficulties in the design of digital circuits arise from this fact.
 </p>
 <figure class="float">
 <a id="Figure-3_002e25"></a>
-<object style="width: 48.52ex; height: 19.17ex;" data="fig/chap3/Fig3.25c.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.25c.std.svg" style="width: 48.52ex; height: 19.17ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.25:</strong> A half-adder circuit.</p>
@@ -1194,7 +1194,7 @@ and an or-gate.<a class="footnote_link" id="DOCF154" href="#FOOT154"><sup>154</s
 
 <figure class="float">
 <a id="Figure-3_002e26"></a>
-<object style="width: 51.29ex; height: 19.17ex;" data="fig/chap3/Fig3.26.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.26.std.svg" style="width: 51.29ex; height: 19.17ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.26:</strong> A full-adder circuit.</p>
@@ -1419,7 +1419,7 @@ and inverters?
 
 <figure class="float">
 <a id="Figure-3_002e27"></a>
-<object style="width: 50.16ex; height: 15.54ex;" data="fig/chap3/Fig3.27b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.27b.std.svg" style="width: 50.16ex; height: 15.54ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.27:</strong> A ripple-carry adder for <math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -1956,7 +1956,7 @@ constant 5 and whose <math xmlns="http://www.w3.org/1998/Math/MathML">
 </p>
 <figure class="float">
 <a id="Figure-3_002e28"></a>
-<object style="width: 58.11ex; height: 18.30ex;" data="fig/chap3/Fig3.28.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.28.std.svg" style="width: 58.11ex; height: 18.30ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.28:</strong> The relation <math xmlns="http://www.w3.org/1998/Math/MathML">

--- a/html/3_002e4.xhtml
+++ b/html/3_002e4.xhtml
@@ -186,7 +186,7 @@ the bank has $75.<a class="footnote_link" id="DOCF164" href="#FOOT164"><sup>164<
 </p>
 <figure class="float">
 <a id="Figure-3_002e29"></a>
-<object style="width: 60.18ex; height: 57.93ex;" data="fig/chap3/Fig3.29b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.29b.std.svg" style="width: 60.18ex; height: 57.93ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.29:</strong> Timing diagram showing how interleaving the order of events in two banking withdrawals can lead to an incorrect final balance.</p>
@@ -233,7 +233,7 @@ Peter’s withdrawal from the shared account.
 </p>
 <figure class="float">
 <a id="Figure-3_002e30"></a>
-<object style="width: 67.52ex; height: 52.84ex;" data="fig/chap3/Fig3.30c.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.30c.std.svg" style="width: 67.52ex; height: 52.84ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.30:</strong> Concurrent deposits and withdrawals from a joint account in Bank1 and a private account in Bank2.</p>

--- a/html/3_002e5.xhtml
+++ b/html/3_002e5.xhtml
@@ -627,7 +627,7 @@ infinite, because the sieve contains a sieve within it.
 </p>
 <figure class="float">
 <a id="Figure-3_002e31"></a>
-<object style="width: 54.05ex; height: 27.89ex;" data="fig/chap3/Fig3.31a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.31a.std.svg" style="width: 54.05ex; height: 27.89ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.31:</strong> The prime sieve viewed as a signal-processing system.</p>
@@ -3039,7 +3039,7 @@ inputs.
 </p>
 <figure class="float">
 <a id="Figure-3_002e32"></a>
-<object style="width: 59.32ex; height: 20.20ex;" data="fig/chap3/Fig3.32a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.32a.std.svg" style="width: 59.32ex; height: 20.20ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.32:</strong> The <code>integral</code> procedure viewed as a signal-processing system.</p>
@@ -3066,7 +3066,7 @@ accompanying signal-flow diagram.
 </p>
 <figure class="float">
 <a id="Figure-3_002e33"></a>
-<object style="width: 50.08ex; height: 37.47ex;" data="fig/chap3/Fig3.33a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.33a.std.svg" style="width: 50.08ex; height: 37.47ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.33:</strong> An RC circuit and the associated signal-flow diagram.</p>
@@ -3276,7 +3276,7 @@ such equations.
 </p>
 <figure class="float">
 <a id="Figure-3_002e34"></a>
-<object style="width: 44.98ex; height: 18.91ex;" data="fig/chap3/Fig3.34.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.34.std.svg" style="width: 44.98ex; height: 18.91ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.34:</strong> An “analog computer circuit” that solves the equation <math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -3570,7 +3570,7 @@ stream of successive values of <math xmlns="http://www.w3.org/1998/Math/MathML">
 
 <figure class="float">
 <a id="Figure-3_002e35"></a>
-<object style="width: 44.72ex; height: 38.94ex;" data="fig/chap3/Fig3.35b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.35b.std.svg" style="width: 44.72ex; height: 38.94ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.35:</strong> Signal-flow diagram for the solution to a second-order linear differential equation.</p>
@@ -3616,7 +3616,7 @@ second-order differential equations <math xmlns="http://www.w3.org/1998/Math/Mat
 
 <figure class="float">
 <a id="Figure-3_002e36"></a>
-<object style="width: 40.49ex; height: 21.76ex;" data="fig/chap3/Fig3.36.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.36.std.svg" style="width: 40.49ex; height: 21.76ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.36:</strong> A series RLC circuit.</p>
@@ -3892,7 +3892,7 @@ shown in <a href="#Figure-3_002e37">Figure 3.37</a>.
 
 <figure class="float">
 <a id="Figure-3_002e37"></a>
-<object style="width: 42.48ex; height: 49.30ex;" data="fig/chap3/Fig3.37.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.37.std.svg" style="width: 42.48ex; height: 49.30ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.37:</strong> A signal-flow diagram for the solution to a series RLC circuit.</p>
@@ -4230,7 +4230,7 @@ process, as shown in <a href="#Figure-3_002e38">Figure 3.38</a>.
 </p>
 <figure class="float">
 <a id="Figure-3_002e38"></a>
-<object style="width: 54.65ex; height: 9.76ex;" data="fig/chap3/Fig3.38a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap3/Fig3.38a.std.svg" style="width: 54.65ex; height: 9.76ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 3.38:</strong> A joint bank account, modeled by merging two streams of transaction requests.</p>

--- a/html/4_002e1.xhtml
+++ b/html/4_002e1.xhtml
@@ -72,7 +72,7 @@ described in <a href="#g_t4_002e1_002e1">4.1.1</a> (see <a href="#Figure-4_002e1
 </p>
 <figure class="float">
 <a id="Figure-4_002e1"></a>
-<object style="width: 60.35ex; height: 24.52ex;" data="fig/chap4/Fig4.1a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap4/Fig4.1a.std.svg" style="width: 60.35ex; height: 24.52ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 4.1:</strong> The <code>eval</code>-<code>apply</code> cycle exposes the essence of a computer language.</p>
@@ -1168,7 +1168,7 @@ together.
 </p>
 <figure class="float">
 <a id="Figure-4_002e2"></a>
-<object style="width: 54.83ex; height: 29.36ex;" data="fig/chap4/Fig4.2a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap4/Fig4.2a.std.svg" style="width: 54.83ex; height: 29.36ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 4.2:</strong> The factorial program, viewed as an abstract machine.</p>
@@ -1183,7 +1183,7 @@ the evaluator will be able to compute factorials.
 </p>
 <figure class="float">
 <a id="Figure-4_002e3"></a>
-<object style="width: 44.98ex; height: 28.32ex;" data="fig/chap4/Fig4.3.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap4/Fig4.3.std.svg" style="width: 44.98ex; height: 28.32ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 4.3:</strong> The evaluator emulating a factorial machine.</p>

--- a/html/4_002e4.xhtml
+++ b/html/4_002e4.xhtml
@@ -1055,7 +1055,7 @@ This stream is the output of the query.
 </p>
 <figure class="float">
 <a id="Figure-4_002e4"></a>
-<object style="width: 56.21ex; height: 22.19ex;" data="fig/chap4/Fig4.4a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap4/Fig4.4a.std.svg" style="width: 56.21ex; height: 22.19ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 4.4:</strong> A query processes a stream of frames.</p>
@@ -1104,7 +1104,7 @@ extended by the second query.
 </p>
 <figure class="float">
 <a id="Figure-4_002e5"></a>
-<object style="width: 55.69ex; height: 22.28ex;" data="fig/chap4/Fig4.5a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap4/Fig4.5a.std.svg" style="width: 55.69ex; height: 22.28ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 4.5:</strong> The <code>and</code> combination of two queries is produced by operating on the stream of frames in series.</p>
@@ -1118,7 +1118,7 @@ streams are then merged to produce the final output stream.
 </p>
 <figure class="float">
 <a id="Figure-4_002e6"></a>
-<object style="width: 58.02ex; height: 35.92ex;" data="fig/chap4/Fig4.6a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap4/Fig4.6a.std.svg" style="width: 58.02ex; height: 35.92ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 4.6:</strong> The <code>or</code> combination of two queries is produced by operating on the stream of frames in parallel and merging the results.</p>

--- a/html/5_002e1.xhtml
+++ b/html/5_002e1.xhtml
@@ -89,7 +89,7 @@ represented in a data-path diagram by a triangle containing the constant).
 </p>
 <figure class="float">
 <a id="Figure-5_002e1"></a>
-<object style="width: 37.90ex; height: 26.07ex;" data="fig/chap5/Fig5.1a.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap5/Fig5.1a.std.svg" style="width: 37.90ex; height: 26.07ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 5.1:</strong> Data paths for a <abbr>GCD</abbr> machine.</p>
@@ -135,7 +135,7 @@ reaches <code>done</code>, we will find the value of the <abbr>GCD</abbr> in reg
 </p>
 <figure class="float">
 <a id="Figure-5_002e2"></a>
-<object style="width: 27.46ex; height: 30.74ex;" data="fig/chap5/Fig5.2.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap5/Fig5.2.std.svg" style="width: 27.46ex; height: 30.74ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 5.2:</strong> Controller for a <abbr>GCD</abbr> machine.</p>
@@ -356,7 +356,7 @@ loops we used in the interpreters of <a href="Chapter-4.xhtml#Chapter-4">Chapter
 </p>
 <figure class="float">
 <a id="Figure-5_002e4"></a>
-<object style="width: 59.92ex; height: 69.76ex;" data="fig/chap5/Fig5.4c.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap5/Fig5.4c.std.svg" style="width: 59.92ex; height: 69.76ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 5.4:</strong> A <abbr>GCD</abbr> machine that reads inputs and prints results.</p>
@@ -401,7 +401,7 @@ instructions that contains a loop, as shown in <a href="#Figure-5_002e6">Figure 
 </p>
 <figure class="float">
 <a id="Figure-5_002e5"></a>
-<object style="width: 44.03ex; height: 70.71ex;" data="fig/chap5/Fig5.5b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap5/Fig5.5b.std.svg" style="width: 44.03ex; height: 70.71ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 5.5:</strong> Data paths and controller for the elaborated <abbr>GCD</abbr> machine.</p>
@@ -474,7 +474,7 @@ corresponding portions of the machine’s controller sequence.
 </p>
 <figure class="float">
 <a id="Figure-5_002e7"></a>
-<object style="width: 56.64ex; height: 63.20ex;" data="fig/chap5/Fig5.7b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap5/Fig5.7b.std.svg" style="width: 56.64ex; height: 63.20ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 5.7:</strong> Portions of the data paths and controller sequence<!-- /@w --> for a machine with two <abbr>GCD</abbr> computations.</p>
@@ -843,7 +843,7 @@ subcomputation, is needed.
 </p>
 <figure class="float">
 <a id="Figure-5_002e11"></a>
-<object style="width: 66.14ex; height: 73.13ex;" data="fig/chap5/Fig5.11b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap5/Fig5.11b.std.svg" style="width: 66.14ex; height: 73.13ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 5.11:</strong> A recursive factorial machine.</p>

--- a/html/5_002e3.xhtml
+++ b/html/5_002e3.xhtml
@@ -157,7 +157,7 @@ here).
 </p>
 <figure class="float">
 <a id="Figure-5_002e14"></a>
-<object style="width: 53.44ex; height: 41.96ex;" data="fig/chap5/Fig5.14b.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap5/Fig5.14b.std.svg" style="width: 53.44ex; height: 41.96ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 5.14:</strong> Box-and-pointer and memory-vector representations of the list <code>((1 2) 3 4)</code>.</p>
@@ -441,7 +441,7 @@ arrangement of memory just before and just after garbage collection.
 </p>
 <figure class="float">
 <a id="Figure-5_002e15"></a>
-<object style="width: 57.59ex; height: 44.47ex;" data="fig/chap5/Fig5.15c.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap5/Fig5.15c.std.svg" style="width: 57.59ex; height: 44.47ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 5.15:</strong> Reconfiguration of memory by the garbage-collection process.</p>

--- a/html/5_002e4.xhtml
+++ b/html/5_002e4.xhtml
@@ -58,7 +58,7 @@ integrated-circuit layout.<a class="footnote_link" id="DOCF304" href="#FOOT304">
 </p>
 <figure class="float">
 <a id="Figure-5_002e16"></a>
-<object style="width: 52.41ex; height: 42.31ex;" data="fig/chap5/chip.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/chap5/chip.std.svg" style="width: 52.41ex; height: 42.31ex;" />
 
 <figcaption class="float-caption">
 <p><strong>Figure 5.16:</strong> A silicon-chip implementation of an evaluator for Scheme.</p>

--- a/html/index.xhtml
+++ b/html/index.xhtml
@@ -35,11 +35,11 @@
 <p>©1996 by The Massachusetts Institute of Technology
 </p>
 
-<object style="width: 2.42ex; height: 2.42ex;" data="fig/icons/cc.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/icons/cc.std.svg" style="width: 2.42ex; height: 2.42ex;" />
 
-<object style="width: 2.42ex; height: 2.42ex;" data="fig/icons/by.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/icons/by.std.svg" style="width: 2.42ex; height: 2.42ex;" />
 
-<object style="width: 2.42ex; height: 2.42ex;" data="fig/icons/sa.std.svg" type="image/svg+xml">SVG</object>
+<img src="fig/icons/sa.std.svg" style="width: 2.42ex; height: 2.42ex;" />
 
 <p>This work is licensed under a Creative Commons Attribution-ShareAlike 4.0
 International License (<a href="http://creativecommons.org/licenses/by-sa/4.0/"><abbr>CC BY-SA 4.0</abbr></a>).

--- a/index.xhtml
+++ b/index.xhtml
@@ -56,7 +56,7 @@ section {
 
 <a class="cover" href="html/index.xhtml">
 <figure>
-<object data="html/fig/coverpage.std.svg" type="image/svg+xml">SVG</object>
+<img src="html/fig/coverpage.std.svg" />
 </figure>
 </a>
 

--- a/lib/Texinfo/Convert/HTML.pm
+++ b/lib/Texinfo/Convert/HTML.pm
@@ -1771,8 +1771,8 @@ sub _convert_image_command($$$$)
       $objectwidth  = (sprintf("%.2f", ($1 * 67.0 / 776)) . "ex");  # 776px or 67ex is the column width at font size 170%.
       $objectheight = (sprintf("%.2f", ($2 * 67.0 / 776)) . "ex");
 
-      return "\n" . "<object style=\"width: $objectwidth; height: $objectheight;\" data=\"" . $self->protect_text($image_file) . 
-        "\" type=\"image/svg+xml\">SVG</object>";  # --> (A.R)
+      return "\n" . "<img style=\"width: $objectwidth; height: $objectheight;\" src=\"" .
+        $self->protect_text($image_file) .  "\" />";  # --> (A.R)
     }
   }
   return '';

--- a/texi2any
+++ b/texi2any
@@ -1,4 +1,4 @@
-#! /usr/bin/perl 
+#! /usr/bin/env perl
 
 # texi2any: Texinfo converter.
 #


### PR DESCRIPTION
Although the 'lib/Texinfo/Convert/HTML.pm' is also modified to produce <img instead of <object for SVG's, I have not been able to test building because of errors probably related to unsupported Perl and/or Texinfo versions(?).